### PR TITLE
mostrar canciones solo songs publicas y privadas a logeados

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -28,3 +28,4 @@ export const verifyToken = (req: Request, res: Response, next: NextFunction) => 
     res.status(401).send(err);
   }
 };
+

--- a/src/controllers/songs/cancion.controller.ts
+++ b/src/controllers/songs/cancion.controller.ts
@@ -1,12 +1,47 @@
-import type { Request, Response } from "express";
+import type { Request, Response, NextFunction } from "express";
 import { PrismaClient } from "@prisma/client";
+import { verifyToken} from "../../auth/auth";
 
 const prisma = new PrismaClient();
 
 
-export const findAll = async (_req: Request, res: Response): Promise<void> => {
+export const findAll = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
-    const songs = await prisma.song.findMany();
+
+    //let songs = await prisma.song.findMany();
+    let songs = await prisma.song.findMany({
+      select: { 
+          id: true,
+          name: true,
+          artist: true,
+          album: true,
+          year: true,
+          genre: true,
+          duration: true,
+          publico: true
+      }
+  });
+    const { authorization } = req.headers;
+    if (!authorization){
+
+      songs = await prisma.song.findMany({ 
+        where: { publico: true },
+        select: { 
+            id: true,
+            name: true,
+            artist: true,
+            album: true,
+            year: true,
+            genre: true,
+            duration: true,
+            publico: true,
+        }
+    });
+
+    }else {
+      verifyToken(req, res, next);
+    }
+    console.log(authorization)
 
     res.status(200).json({
       ok: true,


### PR DESCRIPTION
## DESCRIPCIÓN
- Se filtró las canciones en base si son públicas o privadas.
- Solo usuarios logeados podrán ver tanto canciones publicas y privadas.
- Usuarios NO logeados podrán ver solo canciones públicas.
- También se modificó para que no me muestren los campos update_at y created_at al momento de mostrarme la data de las canciones.